### PR TITLE
Fix shutdown order of containers and add test script

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - name: Test bootstraph.sh
+      - name: Test Scripts
         env:
           SYNADIA_CR_USERNAME: ${{ secrets.SYNADIA_CR_USERNAME }}
           SYNADIA_CR_PASSWORD: ${{ secrets.SYNADIA_CR_PASSWORD }}
@@ -18,8 +18,14 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/main/scripts/bootstrap.sh | bash -s
           cd ./platform-trial
+          ./scripts/test.sh
           ./scripts/stop.sh
-      - name: debug
-        if: always()
+      
+      - name: Debug
+        if: failure()
         run: |
-          cat ./platform-trial/.env
+          cd ./platform-trial
+          cat .env
+          cat shared.conf
+          cat trial.creds
+          cat http-gateway.creds

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
           SYNADIA_CR_USERNAME: ${{ secrets.SYNADIA_CR_USERNAME }}
           SYNADIA_CR_PASSWORD: ${{ secrets.SYNADIA_CR_PASSWORD }}
         shell: bash
-        run: curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/joeriddles/fix-shutdown-order/scripts/bootstrap.sh | bash -s
+        run: curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/main/scripts/bootstrap.sh | bash -s
       
       - name: Test
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
           SYNADIA_CR_PASSWORD: ${{ secrets.SYNADIA_CR_PASSWORD }}
         shell: bash
         run: |
-          curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/main/scripts/bootstrap.sh | bash -s
+          curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/joeriddles/fix-shutdown-order/scripts/bootstrap.sh | bash -s
           cd ./platform-trial
           ./scripts/test.sh
           ./scripts/stop.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ jobs:
           SYNADIA_CR_PASSWORD: ${{ secrets.SYNADIA_CR_PASSWORD }}
         shell: bash
         run: curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/joeriddles/fix-shutdown-order/scripts/bootstrap.sh | bash -s
-          cd ./platform-trial
       
       - name: Test
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,16 +10,23 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - name: Test Scripts
+      - name: Test bootstrap.sh
         env:
           SYNADIA_CR_USERNAME: ${{ secrets.SYNADIA_CR_USERNAME }}
           SYNADIA_CR_PASSWORD: ${{ secrets.SYNADIA_CR_PASSWORD }}
         shell: bash
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/joeriddles/fix-shutdown-order/scripts/bootstrap.sh | bash -s
+        run: curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/joeriddles/fix-shutdown-order/scripts/bootstrap.sh | bash -s
           cd ./platform-trial
-          ./scripts/test.sh
-          ./scripts/stop.sh
+      
+      - name: Test
+        shell: bash
+        working-directory: platform-trial
+        run: ./scripts/test.sh
+      
+      - name: Stop
+        shell: bash
+        working-directory: platform-trial
+        run: ./scripts/stop.sh
       
       - name: Debug
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,8 @@ jobs:
         shell: bash
         run: |
           curl -fsSL https://raw.githubusercontent.com/synadia-io/platform-trial/refs/heads/main/scripts/bootstrap.sh | bash -s
+          cd ./platform-trial
+          ./scripts/stop.sh
       - name: debug
         if: always()
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,11 @@ jobs:
         if: failure()
         run: |
           cd ./platform-trial
+          echo '.env:'
           cat .env
+          echo '\nshared.conf:'
           cat shared.conf
+          echo '\ntrial.creds:'
           cat trial.creds
+          echo '\nhttp-gateway.creds:'
           cat http-gateway.creds

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.creds
 .env
+shared.conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,11 @@ services:
       - "run"
     volumes:
       - ./http-gateway.creds:/http-gateway.creds
+    depends_on:
+      - control-plane
+      - nats1
+      - nats2
+      - nats3
 
 volumes:
   cp-data: {}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -66,7 +66,7 @@ fi
 
 git clone https://github.com/synadia-io/platform-trial.git
 cd ./platform-trial || (echo './platform-trial does not exist' || exit 1)
-git checkout joeriddles/fix-shutdown-order
+git checkout main
 
 # shellcheck source=./common.sh
 . ./scripts/common.sh

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -65,8 +65,8 @@ if [ -n "$debug" ]; then
 fi
 
 git clone https://github.com/synadia-io/platform-trial.git
-git checkout joeriddles/fix-shutdown-order
 cd ./platform-trial || (echo './platform-trial does not exist' || exit 1)
+git checkout joeriddles/fix-shutdown-order
 
 # shellcheck source=./common.sh
 . ./scripts/common.sh

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -65,6 +65,7 @@ if [ -n "$debug" ]; then
 fi
 
 git clone https://github.com/synadia-io/platform-trial.git
+git checkout joeriddles/fix-shutdown-order
 cd ./platform-trial || (echo './platform-trial does not exist' || exit 1)
 
 # shellcheck source=./common.sh

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -126,6 +126,7 @@ retry_with_backoff() {
     rt="$?"
     (( retries+=1 ))
     if [ $retries -gt "$MAX_RETRY" ]; then
+      red "Max retries reached ($MAX_RETRY)" >&2
       exit "$rt"
     fi
   done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# This script checks that the Synadia Platform trial is running correctly.
+
+set -euo pipefail
+
+# shellcheck source=./common.sh
+. ./scripts/common.sh
+
+# Check can connect to HTTP Gateway
+HTTP_GATEWAY_TOKEN=$(grep HTTP_GATEWAY_TOKEN .env | cut -d= -f2 | tr -d '"')
+curl -fsSL -X GET "http://127.0.0.1:8081/v1/kvm/buckets" \
+  -H 'accept: application/json' \
+  -H "authorization: $HTTP_GATEWAY_TOKEN"

--- a/shared.conf
+++ b/shared.conf
@@ -1,6 +1,0 @@
-# This is the shared configuration file for the JetStream
-# and decentralized authentication configuration that will be
-# copied from Control Plane. This must be filled in before
-# starting the NATS cluster.
-
-


### PR DESCRIPTION
- Fix shutdown order of containers. HTTP Gateway depends on control-plane and all the NATS servers.
- Add `test.sh` to verify connecting to HTTP Gateway after `bootstrap.sh` finishes in CI
- Remove `shared.conf` from git since it's only ever populated after bootstrapping the environment and doesn't need to exist to bootstrap

Success CI: https://github.com/synadia-io/platform-trial/actions/runs/13726570436/job/38394322346?pr=2

The test CI is failing because it uses the `main` branch when bootstrapping the repo and `test.sh` does not yet exist. It passes if using this branch (seen in the above link). This failing will go away after this merges.