### PR TITLE
Save admin token to .env file 

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -263,6 +263,9 @@ ADMIN_TOKEN=$(request POST /admin/app-user/ \
 EOF
 )" | jq --raw-output .token)
 
+echo "ADMIN_TOKEN=\"${ADMIN_TOKEN}\"" >> .env
+bold '\nSaved ADMIN_TOKEN to .env\n'
+
 TEAM_ID=$(request GET /teams/ | jq --raw-output '.items[0].id')
 
 SYSTEM_RESPONSE=$(request POST "/teams/${TEAM_ID}/systems" \


### PR DESCRIPTION
Fixes #3 
```
# ./scripts/start.sh  
...
# cat .env
ADMIN_USERNAME=admin
ADMIN_PASSWORD=jKAo2SwQ7ECBduoi
ADMIN_TOKEN="uat_ICY4II1oG9ITLEesgi4h5VbkwAq0Ioe5TyiPF2kDku54AmaybIPvgnt01C0gw9Xg"
HTTP_GATEWAY_TOKEN="nhg_vwdYDy41x8U8vSVk_HjvgMt9PtGg6X5jcBRQ5xQJo7R7Lutecs68MArcNQkvh"
```
